### PR TITLE
Better exit process behavior

### DIFF
--- a/packages/api-extractor-lerna-monorepo/index.js
+++ b/packages/api-extractor-lerna-monorepo/index.js
@@ -96,20 +96,19 @@ async function main({ tsconfigJson, showVerboseMessages } = {}) {
     } catch (e) {
         console.log(`${pkg.name} failed:`);
         console.error(e);
-        process.exitCode = 1;
-
-        return;
+        process.exit(1);
     }
 
     if (extractorResult.succeeded) {
       console.error(`${pkg.name}: completed successfully!`);
-      process.exitCode = 0;
     } else {
       console.error(`${pkg.name}: completed with ${extractorResult.errorCount} errors`
          + ` and ${extractorResult.warningCount} warnings`);
 
       // Don't bother fellas just because of warnings :D
-      process.exitCode = (extractorResult.errorCount > 0);
+      if (extractorResult.errorCount > 0) {
+          process.exit(1);
+      }
     }
   });
 }


### PR DESCRIPTION
This does a hard exit when hitting errors. Here's the example of it in action:

```
@pixi/utils ---------------------------------------------
Analysis will use the bundled TypeScript version 3.9.5
@pixi/utils failed:
Error: The expression contains an import() type, which is not yet supported by API Extractor:
/Users/mattkarl/GitHub/pixijs/pixi.js/out/packages/utils/src/index.d.ts:82:12
    at ExportAnalyzer._tryMatchImportDeclaration (/Users/mattkarl/GitHub/pixijs/pixi.js/node_modules/@microsoft/api-extractor/lib/analyzer/ExportAnalyzer.js:451:19)
    at ExportAnalyzer.fetchReferencedAstEntity (/Users/mattkarl/GitHub/pixijs/pixi.js/node_modules/@microsoft/api-extractor/lib/analyzer/ExportAnalyzer.js:251:45)
    at ExportAnalyzer._tryGetExportOfAstModule (/Users/mattkarl/GitHub/pixijs/pixi.js/node_modules/@microsoft/api-extractor/lib/analyzer/ExportAnalyzer.js:496:34)
    at ExportAnalyzer._getExportOfAstModule (/Users/mattkarl/GitHub/pixijs/pixi.js/node_modules/@microsoft/api-extractor/lib/analyzer/ExportAnalyzer.js:469:32)
    at /Users/mattkarl/GitHub/pixijs/pixi.js/node_modules/@microsoft/api-extractor/lib/analyzer/ExportAnalyzer.js:216:60
    at Map.forEach (<anonymous>)
    at ExportAnalyzer._collectAllExportsRecursive (/Users/mattkarl/GitHub/pixijs/pixi.js/node_modules/@microsoft/api-extractor/lib/analyzer/ExportAnalyzer.js:207:48)
    at ExportAnalyzer.fetchAstModuleExportInfo (/Users/mattkarl/GitHub/pixijs/pixi.js/node_modules/@microsoft/api-extractor/lib/analyzer/ExportAnalyzer.js:157:18)
    at AstSymbolTable.fetchAstModuleExportInfo (/Users/mattkarl/GitHub/pixijs/pixi.js/node_modules/@microsoft/api-extractor/lib/analyzer/AstSymbolTable.js:63:37)
    at Collector.analyze (/Users/mattkarl/GitHub/pixijs/pixi.js/node_modules/@microsoft/api-extractor/lib/collector/Collector.js:128:57)
npm ERR! code 1
npm ERR! path /Users/mattkarl/GitHub/pixijs/pixi.js
npm ERR! command failed
npm ERR! command sh -c rimraf out && tsc && api-extractor-lerna-monorepo && rimraf out && ts-node-script ./scripts/injectGlobalMixins.ts

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/mattkarl/.npm/_logs/2021-03-23T03_30_11_929Z-debug.log
```